### PR TITLE
Add optional API Gateway support to web-holding module

### DIFF
--- a/modules/web-holding/README.md
+++ b/modules/web-holding/README.md
@@ -11,9 +11,10 @@ Use this module when you acquire a new domain and want to set up the core AWS in
 - **Route53 Hosted Zone**: DNS authority for your domain
 - **ACM Certificates**:
   - Global certificate (us-east-1) for CloudFront
-  - Optional regional certificate for services like ALB, API Gateway
+  - Optional regional certificate for services like ALB, API Gateway (auto-enabled if API Gateway is created)
 - **Email Configuration**: Support for Zoho, Gmail, or AWS SES
 - **SES Identity**: Optional AWS SES domain identity and DKIM for sending emails
+- **API Gateway**: Optional API Gateway instance at api.{domain_name}
 
 ## Usage
 
@@ -131,6 +132,12 @@ This module requires two AWS provider configurations:
 | enable_ses_identity | Enable AWS SES domain identity | `bool` | `false` | no |
 | tags | Tags to apply to resources | `map(string)` | `{}` | no |
 | project_name | Project name for tagging | `string` | `"web-holding"` | no |
+| create_api_gateway | Create API Gateway instance | `bool` | `false` | no |
+| api_gateway_name | Name for API Gateway | `string` | `"{project_name}-api"` | no |
+| api_gateway_description | Description for API Gateway | `string` | `"API Gateway"` | no |
+| api_custom_domain_name | Custom domain for API Gateway | `string` | `"api.{domain_name}"` | no |
+| cors_configuration | CORS configuration for API Gateway | `map(any)` | `{allow_headers=["*"], allow_methods=["*"], allow_origins=["*"]}` | no |
+| api_access_log_format | Format for API Gateway access logs | `string` | Standard format | no |
 
 ## Outputs
 
@@ -146,6 +153,11 @@ This module requires two AWS provider configurations:
 | ses_identity_arn | ARN of SES domain identity |
 | ses_verification_token | SES domain verification token |
 | email_provider | Configured email provider |
+| api_gateway_id | ID of the API Gateway (if created) |
+| api_gateway_execution_arn | Execution ARN of the API Gateway (if created) |
+| api_custom_domain_name | Custom domain name for API Gateway (if created) |
+| api_custom_domain_target | Target domain for API Gateway (if created) |
+| api_custom_domain_hosted_zone_id | Hosted zone ID for API Gateway custom domain (if created) |
 
 ## Post-Deployment Steps
 
@@ -158,7 +170,9 @@ This module requires two AWS provider configurations:
 - The module creates wildcard certificates that include the root domain (e.g., `*.example.com` + `example.com`)
 - Certificate validation is automatic via DNS records created in the hosted zone
 - Regional certificate is optional and only needed if you use services like ALB or API Gateway in a specific region
+  - **Note**: Regional certificate is automatically enabled when `create_api_gateway = true`
 - Email provider configuration is optional - use `email_provider = "none"` if managing email elsewhere
+- API Gateway, when enabled, is created at `api.{domain_name}` by default (customizable via `api_custom_domain_name`)
 
 ## Examples by Use Case
 
@@ -207,5 +221,39 @@ module "full_domain" {
   providers = {
     aws.global = aws.global
   }
+}
+```
+
+### Domain with API Gateway
+```hcl
+module "api_domain" {
+  source = "./modules/web-holding"
+
+  domain_name  = "example.com"
+  project_name = "example-com"
+
+  # API Gateway configuration
+  create_api_gateway       = true
+  api_gateway_name         = "example-api"
+  api_gateway_description  = "API services for example.com"
+
+  # Optional: customize API domain (defaults to api.example.com)
+  # api_custom_domain_name = "api.example.com"
+
+  # Email configuration
+  email_provider = "gmail"
+
+  providers = {
+    aws.global = aws.global
+  }
+}
+
+# Use the API Gateway outputs
+output "api_gateway_id" {
+  value = module.api_domain.api_gateway_id
+}
+
+output "api_gateway_execution_arn" {
+  value = module.api_domain.api_gateway_execution_arn
 }
 ```

--- a/modules/web-holding/acm.tf
+++ b/modules/web-holding/acm.tf
@@ -51,7 +51,7 @@ resource "aws_acm_certificate_validation" "global" {
 
 # Regional Certificate (for regional services like ALB, API Gateway)
 resource "aws_acm_certificate" "regional" {
-  count = var.create_regional_cert ? 1 : 0
+  count = local.should_create_regional_cert ? 1 : 0
 
   domain_name               = "*.${var.domain_name}"
   subject_alternative_names = [var.domain_name]
@@ -72,7 +72,7 @@ resource "aws_acm_certificate" "regional" {
 
 # DNS validation records for regional certificate
 resource "aws_route53_record" "regional_cert_validation" {
-  for_each = var.create_regional_cert ? {
+  for_each = local.should_create_regional_cert ? {
     for dvo in aws_acm_certificate.regional[0].domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value
@@ -90,7 +90,7 @@ resource "aws_route53_record" "regional_cert_validation" {
 
 # Certificate validation for regional cert
 resource "aws_acm_certificate_validation" "regional" {
-  count = var.create_regional_cert ? 1 : 0
+  count = local.should_create_regional_cert ? 1 : 0
 
   certificate_arn         = aws_acm_certificate.regional[0].arn
   validation_record_fqdns = [for record in aws_route53_record.regional_cert_validation : record.fqdn]

--- a/modules/web-holding/api-gateway.tf
+++ b/modules/web-holding/api-gateway.tf
@@ -1,0 +1,16 @@
+# Optional API Gateway Integration
+# Creates an API Gateway instance at api.{domain_name} when enabled
+
+module "api" {
+  count  = var.create_api_gateway ? 1 : 0
+  source = "../base-api"
+
+  api_gateway_name        = var.api_gateway_name != "" ? var.api_gateway_name : "${var.project_name}-api"
+  api_gateway_description = var.api_gateway_description
+  custom_domain_name      = var.api_custom_domain_name != "" ? var.api_custom_domain_name : "api.${var.domain_name}"
+  domain_certificate_arn  = local.should_create_regional_cert ? aws_acm_certificate.regional[0].arn : null
+  route53_zone_id         = aws_route53_zone.main.zone_id
+  cors_configuration      = var.cors_configuration
+  access_log_format       = var.api_access_log_format
+  tags                    = var.tags
+}

--- a/modules/web-holding/main.tf
+++ b/modules/web-holding/main.tf
@@ -9,6 +9,12 @@ terraform {
   }
 }
 
+# Local variables
+locals {
+  # Auto-enable regional cert if API Gateway is requested
+  should_create_regional_cert = var.create_regional_cert || var.create_api_gateway
+}
+
 # Route53 Hosted Zone
 resource "aws_route53_zone" "main" {
   name = var.domain_name

--- a/modules/web-holding/outputs.tf
+++ b/modules/web-holding/outputs.tf
@@ -25,12 +25,12 @@ output "global_cert_status" {
 
 output "regional_cert_arn" {
   description = "ARN of the regional ACM certificate"
-  value       = var.create_regional_cert ? aws_acm_certificate.regional[0].arn : null
+  value       = local.should_create_regional_cert ? aws_acm_certificate.regional[0].arn : null
 }
 
 output "regional_cert_status" {
   description = "Status of the regional certificate validation"
-  value       = var.create_regional_cert ? aws_acm_certificate.regional[0].status : null
+  value       = local.should_create_regional_cert ? aws_acm_certificate.regional[0].status : null
 }
 
 output "ses_identity_arn" {
@@ -46,4 +46,31 @@ output "ses_verification_token" {
 output "email_provider" {
   description = "The configured email provider"
   value       = var.email_provider
+}
+
+# API Gateway outputs
+
+output "api_gateway_id" {
+  description = "ID of the API Gateway (if created)"
+  value       = var.create_api_gateway ? module.api[0].api_gateway_id : null
+}
+
+output "api_gateway_execution_arn" {
+  description = "Execution ARN of the API Gateway (if created)"
+  value       = var.create_api_gateway ? module.api[0].api_gateway_execution_arn : null
+}
+
+output "api_custom_domain_name" {
+  description = "Custom domain name for the API Gateway (if created)"
+  value       = var.create_api_gateway ? module.api[0].custom_domain_name : null
+}
+
+output "api_custom_domain_target" {
+  description = "Target domain for the API Gateway (if created)"
+  value       = var.create_api_gateway ? module.api[0].custom_domain_name_target : null
+}
+
+output "api_custom_domain_hosted_zone_id" {
+  description = "Hosted zone ID for the API Gateway custom domain (if created)"
+  value       = var.create_api_gateway ? module.api[0].custom_domain_hosted_zone_id : null
 }

--- a/modules/web-holding/variables.tf
+++ b/modules/web-holding/variables.tf
@@ -66,3 +66,45 @@ variable "project_name" {
   type        = string
   default     = "web-holding"
 }
+
+# API Gateway variables
+
+variable "create_api_gateway" {
+  description = "Create API Gateway instance for this domain"
+  type        = bool
+  default     = false
+}
+
+variable "api_gateway_name" {
+  description = "Name for the API Gateway (defaults to {project_name}-api)"
+  type        = string
+  default     = ""
+}
+
+variable "api_gateway_description" {
+  description = "Description for the API Gateway"
+  type        = string
+  default     = "API Gateway"
+}
+
+variable "api_custom_domain_name" {
+  description = "Custom domain for API Gateway (defaults to api.{domain_name})"
+  type        = string
+  default     = ""
+}
+
+variable "cors_configuration" {
+  description = "CORS configuration for API Gateway"
+  type        = map(any)
+  default = {
+    allow_headers = ["*"]
+    allow_methods = ["*"]
+    allow_origins = ["*"]
+  }
+}
+
+variable "api_access_log_format" {
+  description = "Format for API Gateway access logs"
+  type        = string
+  default     = "$context.identity.sourceIp - - [$context.requestTime] \"$context.httpMethod $context.routeKey $context.protocol\" $context.status $context.responseLength $context.requestId $context.integrationErrorMessage"
+}


### PR DESCRIPTION
## Summary
Extends the web-holding module to optionally create an API Gateway instance when `create_api_gateway = true`.

## Changes
- **New file**: `api-gateway.tf` - Conditional module call to base-api
- **Auto-enable regional cert**: When API Gateway is requested, regional certificate is automatically enabled
- **New variables**: 
  - `create_api_gateway` (bool, default false)
  - `api_gateway_name` (string, defaults to `{project_name}-api`)
  - `api_gateway_description` (string)
  - `api_custom_domain_name` (string, defaults to `api.{domain_name}`)
  - `cors_configuration` (map)
  - `api_access_log_format` (string)
- **New outputs**:
  - `api_gateway_id`
  - `api_gateway_execution_arn`
  - `api_custom_domain_name`
  - `api_custom_domain_target`
  - `api_custom_domain_hosted_zone_id`
- **Updated README**: Added API Gateway examples and documentation

## Usage Example
```hcl
module "my_domain" {
  source = "git::https://github.com/johnsosoka/jscom-tf-modules.git//modules/web-holding?ref=main"
  
  domain_name  = "example.com"
  project_name = "example-com"
  
  # Enable API Gateway
  create_api_gateway       = true
  api_gateway_name         = "example-api"
  api_gateway_description  = "API services for example.com"
  
  providers = {
    aws.global = aws.east
  }
}
```

## Testing Plan
1. Test with sosoka.com to create new API Gateway instance
2. Migrate johnsosoka.com API Gateway from jscom-blog to jscom-core-infrastructure using terraform import